### PR TITLE
docs: add Ubuntu 26.04 to .aar-doc supported OSes

### DIFF
--- a/.aar-doc.yml
+++ b/.aar-doc.yml
@@ -17,8 +17,7 @@ output_template: |
   ## Supported Operating Systems
 
   - Debian 12, 13
-  - Ubuntu 24.04, 22.04
-  - Ubuntu 26.04
+  - Ubuntu 26.04, 24.04, 22.04
   - FreeBSD [Proserver](https://infrastructure.punkt.de/de/produkte/proserver.html)
 
   ## Role Arguments

--- a/.aar-doc.yml
+++ b/.aar-doc.yml
@@ -18,6 +18,7 @@ output_template: |
 
   - Debian 12, 13
   - Ubuntu 24.04, 22.04
+  - Ubuntu 26.04
   - FreeBSD [Proserver](https://infrastructure.punkt.de/de/produkte/proserver.html)
 
   ## Role Arguments

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Elasticsearch role for Proserver
 
 - Debian 12, 13
 - Ubuntu 24.04, 22.04
+- Ubuntu 26.04
 - FreeBSD [Proserver](https://infrastructure.punkt.de/de/produkte/proserver.html)
 
 ## Role Arguments

--- a/README.md
+++ b/README.md
@@ -13,8 +13,7 @@ Elasticsearch role for Proserver
 ## Supported Operating Systems
 
 - Debian 12, 13
-- Ubuntu 24.04, 22.04
-- Ubuntu 26.04
+- Ubuntu 26.04, 24.04, 22.04
 - FreeBSD [Proserver](https://infrastructure.punkt.de/de/produkte/proserver.html)
 
 ## Role Arguments


### PR DESCRIPTION
## Summary
- update `.aar-doc.yml` supported operating systems to include Ubuntu 26.04
- keep existing OS entries unchanged

## Test plan
- [ ] Verify `.aar-doc.yml` includes Ubuntu 26.04 in supported OS list
